### PR TITLE
feat: backend search role listing by role name and filter by skills

### DIFF
--- a/backend/application/dto/role_listing.py
+++ b/backend/application/dto/role_listing.py
@@ -1,4 +1,8 @@
+from typing import List
 from marshmallow import Schema, fields
+from dataclasses import dataclass
+
+from application.models.role_listing import RoleListing
 
 
 class RoleListingDTO(Schema):
@@ -6,7 +10,17 @@ class RoleListingDTO(Schema):
     start_date = fields.Date(required=True)
     end_date = fields.Date(required=True)
 
+
 class UpdateRoleListingDTO(Schema):
     start_date = fields.Date(required=True)
     end_date = fields.Date(required=True)
     status = fields.Str(required=True)
+
+
+@dataclass
+class RoleListingSkillMatchDTO:
+    listing: RoleListing
+    skills_matched: List[str]
+    skills_unmatched: List[str]
+    skills_match_count: int
+    skills_match_pct: float

--- a/backend/application/routes/role_listing_route.py
+++ b/backend/application/routes/role_listing_route.py
@@ -1,14 +1,26 @@
+from typing import List
 from flask import abort, json, jsonify, request, current_app as app
 from marshmallow import ValidationError
 
 from application.models.role_listing import RoleListing
+from application.models.role import Role
+
 # from application.dto.role_listing import UpdateRoleListingDTO
-from application.dto.role_listing import RoleListingDTO, UpdateRoleListingDTO
+from application.dto.role_listing import (
+    RoleListingDTO,
+    RoleListingSkillMatchDTO,
+    UpdateRoleListingDTO,
+)
 from application.services import staff_service
 from . import api
-from application.services import role_listing_service, role_service
+from application.services import role_listing_service, role_service, staff_service
 from application.dto.response import ResponseBodyJSON
 from application.enums import RoleStatus
+from application.extensions import db
+from sqlalchemy import select, text
+
+from flask_sqlalchemy.pagination import SelectPagination
+
 
 DEFAULT_PAGE_SIZE = 10
 
@@ -26,19 +38,53 @@ def find_all_listings_paginated():
     page_size = request.args.get("size", DEFAULT_PAGE_SIZE, type=int)
     page_size = page_size if page_size > 0 else DEFAULT_PAGE_SIZE
 
-    listings = role_listing_service.find_all_paginated(page=page, page_size=page_size)
+    role = request.args.get("role") or ""
+    skills_to_filter = request.args.getlist("skills")
+    app.logger.info(f"GET /listings with params: {request.args}")
 
-    data = {
-        "page": listings.page,
-        "size": listings.per_page,
-        "items": [l.json() for l in listings.items] if listings.items else [],
-        "total": listings.total,
-        "pages": listings.pages,
-        "has_prev": listings.has_prev,
-        "has_next": listings.has_next,
+    # FIXME: get user id from JWT claim to get the user's skills
+    # randomly get a user from the database so simulate a logged in user
+    user = staff_service.find_by_id(3)
+    if user is None:
+        abort(500, description="No user found.")
+
+    user_skills = set([s.name for s in user.skills])
+    app.logger.info(f"user skills: {user_skills}")
+
+    paginated_listings = role_listing_service.find_all_by_role_and_skills_paginated(
+        skills_to_filter=skills_to_filter, role=role, page=page, page_size=page_size
+    )
+
+    data: List[RoleListingSkillMatchDTO] = []
+    for listing in paginated_listings.items:
+        listing_skills = set([s.name for s in listing.role.skills])
+
+        skills_matched = listing_skills.intersection(user_skills)
+        skills_unmatched = listing_skills.difference(user_skills)
+        skills_match_count = len(skills_matched)
+        skills_match_pct = round(skills_match_count / len(listing_skills), 2)
+
+        data.append(
+            RoleListingSkillMatchDTO(
+                listing=listing.json(),
+                skills_matched=list(skills_matched),
+                skills_unmatched=list(skills_unmatched),
+                skills_match_count=skills_match_count,
+                skills_match_pct=skills_match_pct,
+            )
+        )
+
+    res = {
+        "page": paginated_listings.page,
+        "size": paginated_listings.per_page,
+        "items": data,
+        "total": paginated_listings.total,
+        "pages": paginated_listings.pages,
+        "has_prev": paginated_listings.has_prev,
+        "has_next": paginated_listings.has_next,
     }
 
-    return jsonify(data), 200
+    return jsonify(res), 200
 
 
 @api.route("/listings/<int:id>", methods=["GET"])
@@ -83,6 +129,7 @@ def create_listing():
     res = ResponseBodyJSON(data=data.json()).json()
     return jsonify(res), 201
 
+
 @api.route("/listings/<int:id>", methods=["PUT"])
 def update_role_listing(id: int):
     body = request.get_json()
@@ -100,10 +147,20 @@ def update_role_listing(id: int):
 
     # Validate start_time < end_time
     if updated_data["start_date"] >= updated_data["end_date"]:
-        return jsonify({"message": "Invalid start time and end time. Start time must be before the end time."}), 400
+        return (
+            jsonify(
+                {
+                    "message": "Invalid start time and end time. Start time must be before the end time."
+                }
+            ),
+            400,
+        )
 
     # Validate that the status is valid
-    if updated_data["status"] is None or updated_data["status"] not in RoleStatus.__members__:
+    if (
+        updated_data["status"] is None
+        or updated_data["status"] not in RoleStatus.__members__
+    ):
         abort(
             400,
             description=f"Invalid role status: '{id}'. name can only be the following: {RoleStatus.__members__.keys()}",

--- a/backend/application/services/role_listing_service.py
+++ b/backend/application/services/role_listing_service.py
@@ -2,19 +2,41 @@ from typing import List, Optional
 from application.models.role_listing import RoleListing
 from application.extensions import db
 from flask_sqlalchemy.pagination import Pagination
-from sqlalchemy.orm import joinedload
+from sqlalchemy import select
+from application.models.role_skill import role_skills
 
 
-def find_all_paginated(page: int, page_size: int) -> Pagination:
-    # listings = db.session.execute(db.select(RoleListing)).scalars().all() # without pagination
-
-    listings = (
-        RoleListing.query.order_by(RoleListing.end_date.desc())
-        .options(joinedload(RoleListing.role))  # eager load the role object
-        .paginate(page=page, per_page=page_size, error_out=False)
+def find_all_by_role_and_skills_paginated(
+    skills_to_filter: List[str],
+    role: str,
+    page: int,
+    page_size: int,
+) -> Pagination:
+    roles_filtered_by_skills = (
+        (
+            select(role_skills.c.role_name)
+            .where(role_skills.c.skill_name.in_(skills_to_filter))
+            .where(role_skills.c.role_name.icontains(role))
+        )
+        if skills_to_filter
+        else (
+            select(role_skills.c.role_name).where(
+                role_skills.c.role_name.icontains(role)
+            )
+        )
     )
 
-    return listings
+    stmt = (
+        select(RoleListing)
+        .where(
+            RoleListing.start_date <= db.func.current_date(),
+            db.func.current_date() <= RoleListing.end_date,
+        )
+        .where(RoleListing.role_name.in_(roles_filtered_by_skills))
+        .order_by(RoleListing.end_date.desc())
+    )
+
+    return db.paginate(stmt, page=page, per_page=page_size, error_out=False)
 
 
 def find_by_id(id: int) -> Optional[RoleListing]:
@@ -30,6 +52,7 @@ def save(listing: RoleListing) -> RoleListing:
     db.session.add(listing)
     db.session.commit()
     return listing
+
 
 def find_one_random() -> Optional[RoleListing]:
     res = db.session.execute(db.select(RoleListing)).scalars().first()

--- a/backend/application/services/staff_service.py
+++ b/backend/application/services/staff_service.py
@@ -13,6 +13,11 @@ def find_by_id(id: int) -> Optional[Staff]:
     return res
 
 
+def find_one_random() -> Optional[Staff]:
+    res = db.session.execute(db.select(Staff)).scalars().first()
+    return res
+
+
 def create(staff: Staff) -> Staff:
     db.session.add(staff)
     db.session.commit()

--- a/backend/tests/functional/test_role_listing.py
+++ b/backend/tests/functional/test_role_listing.py
@@ -19,9 +19,8 @@ def test_get_indiv_role_listing(test_client: FlaskClient, init_database):
 
     # check response
     assert response.status_code == 200
-    data = response.json["data"]
-    assert data is not None
-    assert data["id"] == id
+    assert response.json is not None
+    assert response.json["listing"]["id"] == id
 
 
 # endregion
@@ -192,7 +191,10 @@ def test_update_role_listing_success(test_client: FlaskClient, init_database):
     assert response.json["data"]["end_date"] == end_date
     assert response.json["data"]["status"] == status
     # Additional assertions to verify the updated data in the response
+
+
 # endregion: end role listings
+
 
 # region: update role listing status not exist
 def test_update_role_listing_status_not_exist(test_client: FlaskClient, init_database):
@@ -220,11 +222,15 @@ def test_update_role_listing_status_not_exist(test_client: FlaskClient, init_dat
     )
     # Check response
     assert response.status_code == 400
+
+
 # endregion: end role listings
 
 
 # region: update role listing start date greater than end date
-def test_update_role_listing_start_date_gt_end_date(test_client: FlaskClient, init_database):
+def test_update_role_listing_start_date_gt_end_date(
+    test_client: FlaskClient, init_database
+):
     """
     GIVEN there is an existing role listing,
     WHEN the API endpoint 'role_listing' is requested (PUT) with request body containing
@@ -249,8 +255,9 @@ def test_update_role_listing_start_date_gt_end_date(test_client: FlaskClient, in
     )
     # Check response
     assert response.status_code == 400
-# endregion: end role listings start date greater than end date
 
+
+# endregion: end role listings start date greater than end date
 
 
 # region: get role listings


### PR DESCRIPTION
### 📋 Overview (what is this PR about) 
Backend support search by role name and filter by skills for front end to view sample data shape
- Updated JSON response for `/api/listings` for paginated role listings with additional fields e.g. skills matched for the user
- Updated JSON response for individual role listing with similar fields as `api/listings`

### 🚀 What are the features/changes included?
- (Search by role name) `api/listings?role={role}` e.g. `api/listings?page=1&size=10&role=de` will search for all role listings containing `de`,  `api/listings?page=1&size=10&role=dev` will search for all role listings containing `dev`,
- (Filter role listings by skills) `api/listings?skills=Problem%20Solving&skills=Communication` will filter role listings by roles that require Problem Solving skill **or** Communication skill.


### 🧪 What testing have I done to make sure it is working?
- Test cases not written yet, will need to use the JWT authorisation features
- The updated endpoints works, tested with postman

### 🧐 How should the reviewer go about testing it?
- Open postman, send `api/listings` to view the new updated data shape
- Open postman, send `api/listings/{id}` to view the new updated data shape

### ✅ Final check
- [ ] I have done the following:
  - `<git rebase main>` to replay your feature commits from the main branch
  - If there are any conflicts, resolve them then run:
    - `git add <resolved rebase conflict files>`
    - `<git rebase --continue>`
    - You may need to run `<git pull>` if your local feature branch is behind the remote feature branch
    - `<git push>`

### 🖼️ Make it visual ✨ (if possible, attach a screenshot of what the reviewer is supposed to see)
 
### ✍️ Any additional notes
- Updated the API Docs on confluence for front end to get data shape of the updated endpoints (`api/listings` and `api/listings/{id}`)