### PR TITLE
chore: filter skills by request param

### DIFF
--- a/backend/application/routes/role_listing_route.py
+++ b/backend/application/routes/role_listing_route.py
@@ -40,10 +40,7 @@ def find_all_listings_paginated():
     app.logger.info(f"GET /listings with params: {request.args}")
 
     role = request.args.get("role") or ""
-    body = request.get_json(silent=True)
-    skills_to_filter = []
-    if body is not None:
-        skills_to_filter = body.get("skills") or []
+    skills_to_filter = request.args.getlist("skills") or []
 
     current_user_id = get_jwt_identity()
     user = staff_service.find_by_id(current_user_id)
@@ -53,7 +50,7 @@ def find_all_listings_paginated():
     user_skills = (
         set([s.name for s in user.skills]) if user.skills is not None else set()
     )
-    app.logger.info(f"user skills: {user_skills}")
+    # app.logger.info(f"user skills: {user_skills}")
 
     paginated_listings = role_listing_service.find_all_by_role_and_skills_paginated(
         skills_to_filter=skills_to_filter, role=role, page=page, page_size=page_size

--- a/backend/application/services/role_listing_service.py
+++ b/backend/application/services/role_listing_service.py
@@ -18,12 +18,12 @@ def find_all_by_role_and_skills_paginated(
         (
             select(role_skills.c.role_name)
             .where(role_skills.c.skill_name.in_(skills_to_filter))
-            .where(role_skills.c.role_name.icontains(role))
+            .where(role_skills.c.role_name.ilike(f"{role}%"))
         )
         if skills_to_filter
         else (
             select(role_skills.c.role_name).where(
-                role_skills.c.role_name.icontains(role)
+                role_skills.c.role_name.ilike(f"{role}%")
             )
         )
     )

--- a/backend/application/services/role_listing_service.py
+++ b/backend/application/services/role_listing_service.py
@@ -17,8 +17,12 @@ def find_all_by_role_and_skills_paginated(
     roles_filtered_by_skills = (
         (
             select(role_skills.c.role_name)
-            .where(role_skills.c.skill_name.in_(skills_to_filter))
-            .where(role_skills.c.role_name.ilike(f"{role}%"))
+            .where(
+                role_skills.c.skill_name.in_(skills_to_filter),
+                role_skills.c.role_name.ilike(f"{role}%"),
+            )
+            .group_by(role_skills.c.role_name)
+            .having(db.func.count(role_skills.c.skill_name) >= len(skills_to_filter))
         )
         if skills_to_filter
         else (
@@ -35,7 +39,7 @@ def find_all_by_role_and_skills_paginated(
             db.func.current_date() <= RoleListing.end_date,
         )
         .where(RoleListing.role_name.in_(roles_filtered_by_skills))
-        .order_by(RoleListing.end_date.desc())
+        .order_by(RoleListing.end_date.asc())
     )
 
     return db.paginate(stmt, page=page, per_page=page_size, error_out=False)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,4 +1,3 @@
-import calendar
 from flask import Flask
 from flask.testing import FlaskClient
 import pytest
@@ -6,7 +5,6 @@ from datetime import date
 from application.config import TestConfig
 from application import init_app
 from application.extensions import db as _db
-from application import register_blueprints, register_error_handlers
 from sqlalchemy.orm import close_all_sessions
 from application.services import staff_service
 from application.enums import AccessControlRole
@@ -306,7 +304,7 @@ def create_role_listings(db):
     mm = today.month
     end_month = (mm % 12) + 1
     yyyy = today.year
-    days = calendar.monthrange(yyyy, mm)[1] - 1
+    days = 25
 
     for i in range(1, days):
         role = role_service.find_one_random()

--- a/backend/tests/functional/test_role_listing.py
+++ b/backend/tests/functional/test_role_listing.py
@@ -579,11 +579,11 @@ def test_get_role_listing_paginated_search_by_role(
 ):
     """
     GIVEN the user is logged in as user, there is a role listing with role name "Software Developer" created,
-    WHEN the API endpoint 'role_listing' is requested (GET) with query params `role=dev`,
+    WHEN the API endpoint 'role_listing' is requested (GET) with query params `role=software`,
     THEN check that
         - the response returns HTTP 200
         - there is at least 1 item in the `items` field
-        - each of the item in the `items` field has a role name that contains "dev"
+        - each of the item in the `items` field has a role name that contains "software"
     """
     # create role listing with role Software Developer
     skills = skill_service.find_unique(2)
@@ -597,7 +597,7 @@ def test_get_role_listing_paginated_search_by_role(
     role_listing = RoleListing(role=role, start_date=start_date, end_date=end_date)
     role_listing_service.save(role_listing)
 
-    response = random_user_client.get(path=ENDPOINT, query_string={"role": "dev"})
+    response = random_user_client.get(path=ENDPOINT, query_string={"role": "software"})
 
     # check response
     assert response.status_code == 200
@@ -659,11 +659,11 @@ def test_get_role_listing_paginated_search_by_skills(
 ):
     """
     GIVEN the user is logged in as user role, there is a role listing created with certain skills,
-    WHEN the API endpoint 'role_listing' is requested (GET) with request body containing the skills,
+    WHEN the API endpoint 'role_listing' is requested (GET) with request param containing the skills,
     THEN check that
         - the response returns HTTP 200
         - there is at least 1 item in the `items` field
-        - each of the item in the `items` field has a role that contains the skills in the request body
+        - each of the item in the `items` field has a role that contains the skills in the request param
     """
     # create role listing with some skills
     skills = skill_service.find_unique(2)
@@ -678,8 +678,11 @@ def test_get_role_listing_paginated_search_by_skills(
     role_listing_service.save(role_listing)
 
     # search by skills
-    body = [skill.name for skill in skills]
-    response = random_user_client.get(path=ENDPOINT, json={"skills": body})
+    request_param = [skill.name for skill in skills]
+    # body = [skill.name for skill in skills]
+    response = random_user_client.get(
+        path=ENDPOINT, query_string={"skills": request_param}
+    )
 
     # check response
     assert response.status_code == 200
@@ -689,7 +692,7 @@ def test_get_role_listing_paginated_search_by_skills(
     assert len(items) > 0
     for item in items:
         skills_required = set(item["listing"]["role"]["skills"])
-        skills_matched = set(body).intersection(skills_required)
+        skills_matched = set(request_param).intersection(skills_required)
         assert len(skills_matched) > 0
 
 
@@ -720,10 +723,11 @@ def test_get_role_listing_paginated_search_by_role_and_skills(
     role_listing_service.save(role_listing)
 
     # search by role and skills
-    body = [skill.name for skill in skills]
-    role_to_search = "man"
+    request_param = [skill.name for skill in skills]
+    role_to_search = "risk"
     response = random_user_client.get(
-        path=ENDPOINT, query_string={"role": role_to_search}, json={"skills": body}
+        path=ENDPOINT,
+        query_string={"role": role_to_search, "skills": request_param},
     )
 
     # check response
@@ -736,7 +740,7 @@ def test_get_role_listing_paginated_search_by_role_and_skills(
         role_res = item["listing"]["role"]
         assert role_to_search in role_res["name"].lower()
         skills_required = set(role_res["skills"])
-        skills_matched = set(body).intersection(skills_required)
+        skills_matched = set(request_param).intersection(skills_required)
         assert len(skills_matched) > 0
 
 


### PR DESCRIPTION
## 📋 Overview (what is this PR about) 
- Update GET `api/listings` endpoint to accept skills by request param instead of request body, and to search for role by matching the first character to last.

## 🚀 What are the features/changes included?
- GET `api/listings` to search by role from first character and skills in request param e.g. `api/listings?role=d&skills=Applications%20Integration&skills=Communication`  will return listings whose name start with `d` and contains skills `Appplications Integration` **and** `Communication`

## 🧪 What testing have I done to make sure it is working?
- Update pytest code
- Tested using postman

## 🧐 How should the reviewer go about testing it?
- Test using postman GET `/api/listings?page=1&size=10&role=dev` should return all role listings start with dev
- Test using postman GET `api/listings?page=1&size=10&skills=Applications Development&skills=Communication` should return all role listings containing skills `Applications Development` **and** `Communication`

## ✅ Final check
- [x] I have done the following:
  - `<git rebase main>` to replay your feature commits from the main branch
  - If there are any conflicts, resolve them then run:
    - `git add <resolved rebase conflict files>`
    - `<git rebase --continue>`
    - You may need to run `<git pull>` if your local feature branch is behind the remote feature branch
    - `<git push>`

## 🖼️ Make it visual ✨ (if possible, attach a screenshot of what the reviewer is supposed to see)
 
## ✍️ Any additional notes
