### PR TITLE
feat: return applicants who applied for role listing

### DIFF
--- a/backend/application/models/staff.py
+++ b/backend/application/models/staff.py
@@ -58,15 +58,15 @@ class Staff(db.Model):
 
     def json(self) -> dict:
         return {
-            "id": self.id,
+            # "id": self.id,
             "fname": self.fname,
             "lname": self.lname,
             "dept": self.dept,
             "country": self.country,
             "email": self.email,
-            "access_control": None
-            if self.access_control is None
-            else self.access_control.json().get("name", None),
+            # "access_control": None
+            # if self.access_control is None
+            # else self.access_control.json().get("name", None),
             # "role_applications": [
             #     application.json() for application in self.applications
             # ],

--- a/backend/application/services/role_listing_service.py
+++ b/backend/application/services/role_listing_service.py
@@ -69,7 +69,7 @@ def find_one_random() -> Optional[RoleListing]:
     return res
 
 
-def construct_indiv_role_listing_dto(staff: Staff, listing: RoleListing):
+def compute_skills_match_data(staff: Staff, listing: RoleListing):
     staff_skills = set(staff.skills)
 
     listing_skills = listing.role.skills
@@ -81,12 +81,10 @@ def construct_indiv_role_listing_dto(staff: Staff, listing: RoleListing):
     skills_match_pct = round(skills_match_count / len(skills_required), 2)
 
     res = {
-        "listing": listing.json(),
         "skills_matched": [s.json() for s in skills_matched],
         "skills_unmatched": [s.json() for s in skills_unmatched],
         "skills_match_count": skills_match_count,
         "skills_match_pct": skills_match_pct,
-        "has_applied": staff in listing.applicants,
     }
 
     return res

--- a/backend/application/services/staff_service.py
+++ b/backend/application/services/staff_service.py
@@ -17,17 +17,17 @@ def find_by_id(id: int) -> Optional[Staff]:
     return res
 
 
-def find_random_user() -> Optional[Staff]:
+def find_random_users(n: int = 1) -> List[Staff]:
     res = (
         db.session.execute(
             select(Staff)
             .join(AccessControl)
             .where(AccessControl.name == AccessControlRole.User.name)
             .order_by(db.func.random())
-            .limit(1)
+            .limit(n)
         )
         .scalars()
-        .first()
+        .all()
     )
 
     return res

--- a/backend/tests/functional/__init__.py
+++ b/backend/tests/functional/__init__.py
@@ -1,0 +1,1 @@
+LISTINGS_ENDPOINT = "/api/listings"

--- a/backend/tests/functional/test_role_listing.py
+++ b/backend/tests/functional/test_role_listing.py
@@ -7,14 +7,7 @@ from application.models.role import Role
 from application.models.skill import Skill
 from application.models.role_listing import RoleListing
 from application.services import skill_service
-
-ENDPOINT = "/api/listings"
-
-
-# def test_stuff(db):
-#     role = Role(name="Astronaut", description="To go to space")
-#     role_service.create(role)
-#     assert role.name == "Astronaut"
+from . import LISTINGS_ENDPOINT as ENDPOINT
 
 
 # region: get individual role listing

--- a/backend/tests/functional/test_role_listing_application.py
+++ b/backend/tests/functional/test_role_listing_application.py
@@ -1,0 +1,54 @@
+from flask.testing import FlaskClient
+from application.models.role_listing import RoleListing
+from . import LISTINGS_ENDPOINT as ENDPOINT
+
+
+# region find role listing applicants
+def test_get_role_listing_applicants_unauthorised_success(
+    random_user_client: FlaskClient, listing_with_applicants: RoleListing
+):
+    """
+    GIVEN the user is logged in as a user,
+    # WHEN the user sends GET request to viewa the role listing applicants,
+    THEN check that
+        - the response returns HTTP 403
+    """
+    response = random_user_client.get(
+        path=f"{ENDPOINT}/{listing_with_applicants.id}/applications",
+    )
+
+    # check response
+    assert response.status_code == 403
+
+
+def test_get_role_listing_applicants_sorted_desc_order_skills_match(
+    random_hr_client: FlaskClient,
+    random_hr_client_x_csrf_token_header,
+    listing_with_applicants: RoleListing,
+):
+    """
+    GIVEN the user is logged in as HR, there is at least one application for a role listing
+    WHEN the user sends GET request to view the role listing applicants,
+    THEN check that
+        - the response returns HTTP 200
+        - the role listing applicants are sorted in descending order of number of skills matched
+    """
+    # given there is a listing with applications
+
+    response = random_hr_client.get(
+        path=f"{ENDPOINT}/{listing_with_applicants.id}/applications",
+        headers=random_hr_client_x_csrf_token_header,
+    )
+
+    # check response
+    assert response.status_code == 200
+    json = response.json
+    applicants = json["applicants"]
+
+    sorted_applicants = sorted(
+        applicants, key=lambda a: a["skills_match_pct"], reverse=True
+    )
+    assert sorted_applicants == applicants
+
+
+# endregion


### PR DESCRIPTION
## 📋 Overview (what is this PR about) 
- Endpoint to return applicants who applied for a role listing

## 🚀 What are the features/changes included?
- `GET /api/listings/{id}/applications` will return list of applicants who have applied for a role listing, sorted in descending order of skills match percentage. The endpoint is only accessible by user roles (HR or admin).

## 🧪 What testing have I done to make sure it is working?
- Pytest test cases
- Tested with postman

## 🧐 How should the reviewer go about testing it?
- Refer to google sheets, use postman to verify results

## 🖼️ Make it visual ✨ (if possible, attach a screenshot of what the reviewer is supposed to see)
 
## ✍️ Any additional notes
