### PR TITLE
feat: return relevant listings for user based on skills

### DIFF
--- a/backend/application/models/role.py
+++ b/backend/application/models/role.py
@@ -13,7 +13,7 @@ class Role(db.Model):
     role_listing = relationship("RoleListing", back_populates="role", lazy=True)
 
     skills = relationship(
-        "Skill", secondary=role_skills, lazy="subquery", back_populates="roles"
+        "Skill", secondary=role_skills, lazy=True, back_populates="roles"
     )
 
     @property

--- a/backend/application/models/role_listing.py
+++ b/backend/application/models/role_listing.py
@@ -39,7 +39,7 @@ class RoleListing(db.Model):
         name="status", type_=Enum(RoleStatus), nullable=False, default=RoleStatus.OPEN
     )
 
-    role = db.relationship("Role", back_populates="role_listing", lazy="subquery")
+    role = db.relationship("Role", back_populates="role_listing", lazy="joined")
 
     applicants = relationship(
         "Staff",

--- a/backend/application/models/staff.py
+++ b/backend/application/models/staff.py
@@ -58,15 +58,15 @@ class Staff(db.Model):
 
     def json(self) -> dict:
         return {
-            "id": self.id,
+            # "id": self.id,
             "fname": self.fname,
             "lname": self.lname,
             "dept": self.dept,
             "country": self.country,
             "email": self.email,
-            "access_control": None
-            if self.access_control is None
-            else self.access_control.json().get("name", None),
+            # "access_control": None
+            # if self.access_control is None
+            # else self.access_control.json().get("name", None),
             # "role_applications": [
             #     application.json() for application in self.applications
             # ],

--- a/backend/application/models/staff.py
+++ b/backend/application/models/staff.py
@@ -36,7 +36,7 @@ class Staff(db.Model):
         "Skill",
         secondary=staff_skills,
         back_populates="staff_with_skill",
-        lazy="subquery",
+        lazy=True,
     )
 
     applications = relationship(

--- a/backend/application/services/role_listing_service.py
+++ b/backend/application/services/role_listing_service.py
@@ -69,7 +69,7 @@ def find_one_random() -> Optional[RoleListing]:
     return res
 
 
-def construct_indiv_role_listing_dto(staff: Staff, listing: RoleListing):
+def compute_skills_match_data(staff: Staff, listing: RoleListing):
     staff_skills = set(staff.skills)
 
     listing_skills = listing.role.skills
@@ -81,12 +81,10 @@ def construct_indiv_role_listing_dto(staff: Staff, listing: RoleListing):
     skills_match_pct = round(skills_match_count / len(skills_required), 2)
 
     res = {
-        "listing": listing.json(),
         "skills_matched": [s.json() for s in skills_matched],
         "skills_unmatched": [s.json() for s in skills_unmatched],
         "skills_match_count": skills_match_count,
         "skills_match_pct": skills_match_pct,
-        "has_applied": staff in listing.applicants,
     }
 
     return res

--- a/backend/application/services/role_listing_service.py
+++ b/backend/application/services/role_listing_service.py
@@ -6,6 +6,7 @@ from sqlalchemy import select
 from application.models.role_skill import role_skills
 from application.models.role_application import role_applications
 from application.models.staff import Staff
+from application.enums import RoleStatus
 
 
 def find_all_by_role_and_skills_paginated(
@@ -106,3 +107,44 @@ def delete_role_application(role_listing_id: int, staff_id: int):
     )
     db.session.execute(stmt)
     db.session.commit()
+
+
+def find_by_most_matched_skills(
+    skills_to_filter: List[str], limit: int = 10
+) -> List[RoleListing]:
+    open_listings = (
+        select(RoleListing.role_name)
+        .where(
+            RoleListing.start_date <= db.func.current_date(),
+            db.func.current_date() <= RoleListing.end_date,
+            RoleListing.status == RoleStatus.OPEN.value,
+        )
+        .distinct(RoleListing.role_name)
+    )
+
+    best_matched_roles = (
+        select(RoleListing.role_name)
+        .join(role_skills, RoleListing.role_name == role_skills.c.role_name)
+        .where(
+            role_skills.c.role_name.in_(open_listings),
+            role_skills.c.skill_name.in_(skills_to_filter),
+        )
+        .group_by(RoleListing.role_name)
+        .order_by(
+            (
+                db.func.count(db.func.distinct(role_skills.c.skill_name))
+                / len(skills_to_filter)
+            ).desc()
+        )
+        .limit(limit)
+    )
+    stmt = (
+        select(RoleListing)
+        .distinct(RoleListing.role_name)  # return role listings with unique role names
+        .where(
+            RoleListing.role_name.in_(best_matched_roles),
+        )
+    )
+
+    res = db.session.execute(stmt).scalars().all()
+    return res

--- a/backend/application/services/staff_service.py
+++ b/backend/application/services/staff_service.py
@@ -17,17 +17,17 @@ def find_by_id(id: int) -> Optional[Staff]:
     return res
 
 
-def find_random_user() -> Optional[Staff]:
+def find_random_users(n: int = 1) -> List[Staff]:
     res = (
         db.session.execute(
             select(Staff)
             .join(AccessControl)
             .where(AccessControl.name == AccessControlRole.User.name)
             .order_by(db.func.random())
-            .limit(1)
+            .limit(n)
         )
         .scalars()
-        .first()
+        .all()
     )
 
     return res

--- a/backend/tests/functional/__init__.py
+++ b/backend/tests/functional/__init__.py
@@ -1,0 +1,1 @@
+LISTINGS_ENDPOINT = "/api/listings"

--- a/backend/tests/functional/test_role_listing.py
+++ b/backend/tests/functional/test_role_listing.py
@@ -815,3 +815,35 @@ def test_withdraw_role_listing_success(
 
 
 # endregion
+
+
+# region Get relevant role listings by most matched skills
+def test_relevant_role_listings_by_most_matched_skills(
+    random_user_client: FlaskClient,
+    init_database,
+    create_role_listings,
+):
+    """
+    GIVEN the user is logged in as user, there are role listings created,
+    WHEN user sends request to view the listings that has most matched skills
+    THEN check that
+        - the response returns HTTP 200
+        - the listings returned are sorted in descending order of percentage of user's matched skills with the listing's skills
+    """
+
+    response = random_user_client.get(
+        path=f"{ENDPOINT}/relevant",
+    )
+
+    # check response
+    assert response.status_code == 200
+    data = response.json
+    listings = data["listings"]
+
+    sorted_listings = sorted(
+        listings, key=lambda l: l["skills_match_pct"], reverse=True
+    )
+    assert listings == sorted_listings
+
+
+# endregion

--- a/backend/tests/functional/test_role_listing.py
+++ b/backend/tests/functional/test_role_listing.py
@@ -7,14 +7,7 @@ from application.models.role import Role
 from application.models.skill import Skill
 from application.models.role_listing import RoleListing
 from application.services import skill_service
-
-ENDPOINT = "/api/listings"
-
-
-# def test_stuff(db):
-#     role = Role(name="Astronaut", description="To go to space")
-#     role_service.create(role)
-#     assert role.name == "Astronaut"
+from . import LISTINGS_ENDPOINT as ENDPOINT
 
 
 # region: get individual role listing

--- a/backend/tests/functional/test_role_listing_application.py
+++ b/backend/tests/functional/test_role_listing_application.py
@@ -1,0 +1,54 @@
+from flask.testing import FlaskClient
+from application.models.role_listing import RoleListing
+from . import LISTINGS_ENDPOINT as ENDPOINT
+
+
+# region find role listing applicants
+def test_get_role_listing_applicants_unauthorised_success(
+    random_user_client: FlaskClient, listing_with_applicants: RoleListing
+):
+    """
+    GIVEN the user is logged in as a user,
+    # WHEN the user sends GET request to viewa the role listing applicants,
+    THEN check that
+        - the response returns HTTP 403
+    """
+    response = random_user_client.get(
+        path=f"{ENDPOINT}/{listing_with_applicants.id}/applications",
+    )
+
+    # check response
+    assert response.status_code == 403
+
+
+def test_get_role_listing_applicants_sorted_desc_order_skills_match(
+    random_hr_client: FlaskClient,
+    random_hr_client_x_csrf_token_header,
+    listing_with_applicants: RoleListing,
+):
+    """
+    GIVEN the user is logged in as HR, there is at least one application for a role listing
+    WHEN the user sends GET request to view the role listing applicants,
+    THEN check that
+        - the response returns HTTP 200
+        - the role listing applicants are sorted in descending order of number of skills matched
+    """
+    # given there is a listing with applications
+
+    response = random_hr_client.get(
+        path=f"{ENDPOINT}/{listing_with_applicants.id}/applications",
+        headers=random_hr_client_x_csrf_token_header,
+    )
+
+    # check response
+    assert response.status_code == 200
+    json = response.json
+    applicants = json["applicants"]
+
+    sorted_applicants = sorted(
+        applicants, key=lambda a: a["skills_match_pct"], reverse=True
+    )
+    assert sorted_applicants == applicants
+
+
+# endregion


### PR DESCRIPTION
## 📋 Overview (what is this PR about) 
- API endpoint to return `n` listings with unique role names that has highest % match with the user's skills.

## 🚀 What are the features/changes included?
- `GET /api/listings/relevant?limit={limit}` returns list of `limit` number of listings sorted in descending order of % of user's skills matched with the role listing's skills. `limit` request param is optional (defaults to 10 listings) if not given.

## 🧪 What testing have I done to make sure it is working?
- Pytest testing
- Postman testing

## 🧐 How should the reviewer go about testing it?
Refer to google sheets and test with postman

## 🖼️ Make it visual ✨ (if possible, attach a screenshot of what the reviewer is supposed to see)
 
## ✍️ Any additional notes
