### PR TITLE
feat: add waitress as wsgi server

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,5 @@
-FROM python:3.11-buster
+FROM python:3.11.6-slim
 WORKDIR /app
-
-RUN useradd -r -s /bin/bash appuser
 
 ENV PYTHONFAULTHANDLER=1 \
     PYTHONUNBUFFERED=1 \
@@ -9,14 +7,18 @@ ENV PYTHONFAULTHANDLER=1 \
     PIP_NO_CACHE_DIR=off \
     PIP_DISABLE_PIP_VERSION_CHECK=on \
     PIP_DEFAULT_TIMEOUT=100 \
-    POETRY_VERSION=1.4.0
+    POETRY_VERSION=1.6.1
 
 RUN pip install "poetry==$POETRY_VERSION"
 
-COPY . ./
-RUN poetry config virtualenvs.create false \
+COPY poetry.lock pyproject.toml ./
+
+RUN poetry config virtualenvs.create true \
     && poetry install --no-interaction --no-ansi
+
+COPY . .
 
 EXPOSE 5000
 
-CMD [ "python", "./wsgi.py" ]
+# Run Flask app
+CMD ["poetry", "run", "waitress-serve", "--port", "5000", "wsgi:app"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -47,6 +47,13 @@ poetry install
 poetry run python -m flask --app wsgi:app run
 ```
 
+### Running backend with Waitress server (production)
+
+```
+cd backend
+poetry run waitress-serve --port 5000 wsgi:app
+```
+
 ### Running tests
 
 ```

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -613,6 +613,21 @@ files = [
 ]
 
 [[package]]
+name = "waitress"
+version = "2.1.2"
+description = "Waitress WSGI server"
+optional = false
+python-versions = ">=3.7.0"
+files = [
+    {file = "waitress-2.1.2-py3-none-any.whl", hash = "sha256:7500c9625927c8ec60f54377d590f67b30c8e70ef4b8894214ac6e4cad233d2a"},
+    {file = "waitress-2.1.2.tar.gz", hash = "sha256:780a4082c5fbc0fde6a2fcfe5e26e6efc1e8f425730863c04085769781f51eba"},
+]
+
+[package.extras]
+docs = ["Sphinx (>=1.8.1)", "docutils", "pylons-sphinx-themes (>=1.0.9)"]
+testing = ["coverage (>=5.0)", "pytest", "pytest-cover"]
+
+[[package]]
 name = "werkzeug"
 version = "3.0.0"
 description = "The comprehensive WSGI web application library."
@@ -632,4 +647,4 @@ watchdog = ["watchdog (>=2.3)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "4c10b1e74ee0e698073337fb9e2a1f2c4b77b8127abd355548c8689a1a15a565"
+content-hash = "63928ab717b69c88b73a777894a390d257525d32923c2ef0b5cb5b6529b5f370"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -17,6 +17,7 @@ marshmallow = "^3.20.1"
 load-dotenv = "^0.1.0"
 flask-jwt-extended = "^4.5.2"
 flask-migrate = "^4.0.5"
+waitress = "^2.1.2"
 
 
 [build-system]


### PR DESCRIPTION
## 📋 Overview (what is this PR about) 
- Add `Waitress` python library as production ready server instead of using flask's werkzeug development server (not safe for when deploying to production)

## 🚀 What are the features/changes included?
- Added waitress to poetry dependency
- Updated dockerfile to run the backend using `waitress`

## 🧪 What testing have I done to make sure it is working?
- Tested by running the docker container 

## 🧐 How should the reviewer go about testing it?
- Test locally
```
cd backend
poetry run waitress-serve --port 5000 wsgi:app
```
Test out API endpoints using postman e.g. POST api/login, GET api/listings. 

- Run docker desktop
```
cd backend
docker build -t backend .
docker run -d -p 5000:5000 --name backend_container backend
```
Test out API endpoints using postman e.g. POST api/login, GET api/listings; the backend docker container should be handling the requests as port 5000 is mapped from local machine to the docker container port 5000.

Stopping the docker container
`docker stop backend_container`


## 🖼️ Make it visual ✨ (if possible, attach a screenshot of what the reviewer is supposed to see)
 
## ✍️ Any additional notes
